### PR TITLE
fix: rawpasssize can use int or long long values if the size is too big

### DIFF
--- a/src/GERawConverter.cpp
+++ b/src/GERawConverter.cpp
@@ -347,7 +347,20 @@ std::string GERawConverter::ge_header_to_xml(GERecon::Legacy::LxDownloadDataPoin
     writer.formatElement("ScanCenter", "%f",       processingControl->Value<float>("ScanCenter"));
     writer.formatElement("Landmark", "%f",         processingControl->Value<float>("Landmark"));
     writer.formatElement("CoilConfigUID", "%u",    processingControl->Value<unsigned int>("CoilConfigUID"));
-    writer.formatElement("RawPassSize", "%llu",    processingControl->Value<int>("RawPassSize"));
+    try {
+        // Attempt to use `int` for RawPassSize
+        writer.formatElement("RawPassSize", "%llu", processingControl->Value<int>("RawPassSize"));
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to retrieve RawPassSize as int: " << e.what() << ". Trying unsigned long long instead." << std::endl;
+        try {
+            // Fallback to `unsigned long long` if the first attempt fails
+            writer.formatElement("RawPassSize", "%llu", processingControl->Value<unsigned long long>("RawPassSize"));
+        } catch (const std::exception& e) {
+            // If both attempts fail, set a default value and continue
+            std::cerr << "Failed to retrieve RawPassSize as unsigned long long: " << e.what() << ". Using default value 0." << std::endl;
+            writer.formatElement("RawPassSize", "%llu", 0ULL); // Default value
+        }
+    }
 
     // ReconstructionParameters
     writer.addBooleanElement("CreateMagnitudeImages", processingControl->Value<bool>("CreateMagnitudeImages"));


### PR DESCRIPTION
Allows to use unsigned long long if value can't fit into an int causing an error and not converting.

Avoids error: `Failed to get header string: bad numeric conversion: positive overflow`

Milton